### PR TITLE
Fix blog link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@
 This project shows how to use Django Allauth after having removed the
 username field from your model.
 
-It's a companion to a blog post I wrote about [how to remove the username field from Django's default User model](https://djangoreacts.com/remove-username-django-user-model/).
+It's a companion to a blog post I wrote about [how to remove the username field from Django's default User model](https://joshkaramuth.com/blog/django-allauth-without-username-field/).


### PR DESCRIPTION
Hello, I just wanted to thank you for your work on your "django-allauth-no-username" repo.  I've been working with Django since 1.0 was released and have always been frustrated with Django's favouring of the `username` field.  Every time I've tried to avoid using it though I've run into problems, especially when using allauth.

So to run into a clear, concise and limited-to-just-what-you're-trying-to-convey repo on exactly this topic was fantastic!  Unfortunately, the link in the README appears to have gone stale, so I took the opportunity to offer a fix :-)

Anyway, yeah, thanks for being awesome :-)